### PR TITLE
Use the standard `viewLoaded` property from UIViewController

### DIFF
--- a/ABFRealmTableViewController/ABFRealmTableViewController.m
+++ b/ABFRealmTableViewController/ABFRealmTableViewController.m
@@ -13,9 +13,6 @@
 #import <RBQFetchedResultsController/RBQFetchRequest.h>
 
 @interface ABFRealmTableViewController () <RBQFetchedResultsControllerDelegate>
-
-@property (assign, nonatomic) BOOL viewLoaded;
-
 @end
 
 @implementation ABFRealmTableViewController
@@ -76,8 +73,6 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    
-    self.viewLoaded = YES;
     
     [self updateFetchedResultsController];
 }
@@ -162,7 +157,7 @@
                                            sectionNameKeyPath:self.sectionNameKeyPath
                                               andPerformFetch:YES];
             
-            if (self.viewLoaded) {
+            if (self.isViewLoaded) {
                 typeof(self) __weak weakSelf = self;
                 
                 [self runOnMainThread:^{


### PR DESCRIPTION
The `viewLoaded` in ABFRealmTableViewController conflicts with the same property of UIViewController defined as
@property(nonatomic, readonly, getter=isViewLoaded) BOOL viewLoaded NS_AVAILABLE_IOS(3_0);

The compiler gives this warning:
> ABFRealmTableViewController.m:17:36: Auto property synthesis will not synthesize property 'viewLoaded' because it is 'readwrite' but it will be synthesized 'readonly' via another property

The solution is to simply use UIViewController’s isViewLoaded which has the same semantics as ABFRealmTableViewController’s viewLoaded property.